### PR TITLE
Remove `const` from `Fixture::into_content`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["dir-test", "macros"]
+resolver = "2"

--- a/dir-test/src/lib.rs
+++ b/dir-test/src/lib.rs
@@ -146,7 +146,7 @@ impl<T> Fixture<T> {
     }
 
     /// Consumes the fixture and returns the content.
-    pub const fn into_content(self) -> T {
+    pub fn into_content(self) -> T {
         self.content
     }
 


### PR DESCRIPTION
This PR just removes `const` from `Fixture::into_content`. This is necessary because of rustc's const live drop analysis is not precise enough to allow this case. 
Ref 
* https://github.com/rust-lang/rust/issues/60964
* https://github.com/rust-lang/rust/issues/73255

@akonradi-signal Sorry, I didn't notice this error when I merged #2.
