### PR TITLE
Allow for return types

### DIFF
--- a/dir-test/src/lib.rs
+++ b/dir-test/src/lib.rs
@@ -136,7 +136,7 @@
 //!     dir: "$CARGO_MANIFEST_DIR/fixtures",
 //!     glob: "**/*.txt",
 //! )]
-//! fn test(fixture: Fixture<&str>) -> io::Result<()> {
+//! fn test(fixture: Fixture<&str>) -> std::io::Result<()> {
 //!     // ...
 //! }
 //! ```

--- a/dir-test/src/lib.rs
+++ b/dir-test/src/lib.rs
@@ -123,6 +123,23 @@
 //!
 //! **NOTE**: The `dir_test_attr` attribute must be specified after the
 //! `dir_test`.
+//!
+//!  ### Return Types
+//!  Tests may have a return type, allowing for the [`Result<T, E>`] type to be used in the test.
+//! See the relevant book link
+//! [here](https://doc.rust-lang.org/book/ch11-01-writing-tests.html#using-resultt-e-in-tests).
+//!
+//! ```rust, no_run
+//! use dir_test::{dir_test, Fixture};
+//!
+//! #[dir_test(
+//!     dir: "$CARGO_MANIFEST_DIR/fixtures",
+//!     glob: "**/*.txt",
+//! )]
+//! fn test(fixture: Fixture<&str>) -> io::Result<()> {
+//!     // ...
+//! }
+//! ```
 
 /// A fixture contains a file content and its absolute path.
 /// Content type is determined by the loader function specified in

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -86,6 +86,7 @@ impl TestBuilder {
         let test_name = self.test_name(file_path)?;
         let file_path_str = file_path.to_string_lossy();
         let test_func = &self.func.sig.ident;
+        let return_ty = &self.func.sig.output;
         let test_attrs = &self.test_attrs;
 
         let loader = match self.dir_test_arg.loader {
@@ -96,8 +97,8 @@ impl TestBuilder {
         Ok(quote! {
             #(#test_attrs)*
             #[test]
-            fn #test_name() {
-                #test_func(::dir_test::Fixture::new(#loader(#file_path_str), #file_path_str));
+            fn #test_name() #return_ty {
+                #test_func(::dir_test::Fixture::new(#loader(#file_path_str), #file_path_str))
             }
         })
     }


### PR DESCRIPTION
Thanks for the great crate! This PR allows return types in test functions (namely for `Result<T>`).