### PR TITLE
Make clippy happy

### DIFF
--- a/dir-test/src/lib.rs
+++ b/dir-test/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::test_attr_in_doctest)]
+#![cfg(not(doctest))]
 //! `dir-test` provides a macro to generate single test cases from files in a
 //! directory.
 //!


### PR DESCRIPTION
1. Fix clippy warning
2. Specify `not(doctest)` in the main module