### PR TITLE
Prefix generated test names with user-defined test fn name

### DIFF
--- a/dir-test/README.md
+++ b/dir-test/README.md
@@ -20,7 +20,7 @@ use dir_test::{dir_test, Fixture};
     dir: "$CARGO_MANIFEST_DIR/fixtures",
     glob: "**/*.txt",
 )]
-fn test(fixture: Fixture<&str>) {
+fn mytest(fixture: Fixture<&str>) {
     // The file content and the absolute path of the file are available as follows.
     let content = fixture.content();
     let path = fixture.path();
@@ -31,7 +31,7 @@ fn test(fixture: Fixture<&str>) {
 ```
 
 Assuming your crate is as follows, then the above code generates two test
-cases `foo()` and `fixtures_a_bar()`.
+cases `mytest__foo()` and `mytest__fixtures_a_bar()`.
 
 ```text
 my-crate/
@@ -50,13 +50,13 @@ my-crate/
 
 ```rust, no_run
 #[test]
-fn foo() {
-    test(fixture);
+fn mytest__foo() {
+    mytest(fixture);
 }
 
 #[test]
-fn fixtures_a_bar() {
-    test(fixture);
+fn mytest__fixtures_a_bar() {
+    mytest(fixture);
 }
 ```
 

--- a/dir-test/src/lib.rs
+++ b/dir-test/src/lib.rs
@@ -19,7 +19,7 @@
 //!     dir: "$CARGO_MANIFEST_DIR/fixtures",
 //!     glob: "**/*.txt",
 //! )]
-//! fn test(fixture: Fixture<&str>) {
+//! fn mytest(fixture: Fixture<&str>) {
 //!     // The file content and the absolute path of the file are available as follows.
 //!     let content = fixture.content();
 //!     let path = fixture.path();
@@ -30,7 +30,7 @@
 //! ```
 //!
 //! Assuming your crate is as follows, then the above code generates two test
-//! cases `foo()` and `fixtures_a_bar()`.
+//! cases `mytest__foo()` and `mytest__fixtures_a_bar()`.
 //!
 //! ```text
 //! my-crate/
@@ -49,13 +49,13 @@
 //!
 //! ```rust, no_run
 //! #[test]
-//! fn foo() {
-//!     test(fixture);
+//! fn mytest__foo() {
+//!     mytest(fixture);
 //! }
 //!
 //! #[test]
-//! fn fixtures_a_bar() {
-//!     test(fixture);
+//! fn mytest__fixtures_a_bar() {
+//!     mytest(fixture);
 //! }
 //! ```
 //!

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -83,9 +83,9 @@ impl TestBuilder {
     }
 
     fn build_test(&self, file_path: &Path) -> Result<proc_macro2::TokenStream> {
-        let test_name = self.test_name(file_path)?;
-        let file_path_str = file_path.to_string_lossy();
         let test_func = &self.func.sig.ident;
+        let test_name = self.test_name(test_func.to_string(), file_path)?;
+        let file_path_str = file_path.to_string_lossy();
         let return_ty = &self.func.sig.output;
         let test_attrs = &self.test_attrs;
 
@@ -103,14 +103,16 @@ impl TestBuilder {
         })
     }
 
-    fn test_name(&self, fixture_path: &Path) -> Result<syn::Ident> {
+    fn test_name(&self, test_func_name: String, fixture_path: &Path) -> Result<syn::Ident> {
         assert!(fixture_path.is_file());
 
         let dir_path = self.dir_test_arg.resolve_dir()?;
         let rel_path = fixture_path.strip_prefix(dir_path).unwrap();
         assert!(rel_path.is_relative());
 
-        let mut test_name = String::new();
+        let mut test_name = test_func_name;
+        test_name.push_str("__");
+
         let components: Vec<_> = rel_path.iter().collect();
 
         for component in &components[0..components.len() - 1] {


### PR DESCRIPTION
I ran into a minor problem with code like this:

```rust 
#[dir_test(
    dir: "$CARGO_MANIFEST_DIR/test_files/syntax/func",
    glob: "*.sntn"
)]
fn test_func(fixture: Fixture<&str>) {
    test_rule(Rule::functions, fixture)
}

#[dir_test(
    dir: "$CARGO_MANIFEST_DIR/test_files/syntax/module",
    glob: "*.sntn"
)]
fn test_module(fixture: Fixture<&str>) {
    test_rule(Rule::module, fixture)
}
```
where both of the directories contain a file called "simple.sntn", and thus two test functions called "simple" are generated. I could have manually specified a suffix to the `dir_test` attribute, but I think it's better for this situation to work by default. I solved this by prefixing the generated test names with the name of the function that the `dir_test` attribute is attached to; in this case the generated tests are `test_func__simple` and `test_module__simple`.

This change is also makes the `cargo test` output more clear when there are many test functions specified, and files with generic name. Eg
```
test test_item_list__use ... ok
test test_pat__record ... ok
test test_struct__empty ... ok
test test_stmt__assign ... ok
test test_struct__attr ... ok
test test_stmt__while ... ok
test test_stmt__for ... ok
test test_pat__path_tuple ... ok
```

